### PR TITLE
feat: add only-year flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ There is a configuration file left in `~/.config/scdl/scdl.cfg`
 ## Contributing
 TODO:
 
+install dev dependencies
+
 lint with `ruff check`
 
 type check with `mypy`
@@ -110,6 +112,7 @@ scdl -l https://soundcloud.com/ihatemyselfbeats/t-1 --impersonate chrome
 --no-playlist                   Skip downloading playlists
 --opus                          Prefer downloading opus streams over mp3 streams
 --impersonate [target]          Forward yt-dlp's --impersonate (requires curl_cffi)
+--only-year                     Sets the year tag to be %yyyy instead of %yyyy-%mm-%dd
 --yt-dlp-args                   String with custom args to forward to yt-dlp
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ https://github.com/flyingrub/scdl/wiki/Installation-Instruction
 ## Configuration
 There is a configuration file left in `~/.config/scdl/scdl.cfg`
 
+## Contributing
+TODO:
+
+lint with `ruff check`
+
+type check with `mypy`
+
+run tests with `pytest`
+
 ## Examples:
 ```
 # Download track & repost of the user QUANTA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 
 [dependency-groups]
 dev = [
+    "curl_cffi>=0.14.0",
     "music-tag>=0.4.3",
     "mypy>=1.13.0",
     "pytest>=8.3.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
 
 [dependency-groups]
 dev = [
-    "curl_cffi>=0.14.0",
     "music-tag>=0.4.3",
     "mypy>=1.13.0",
     "pytest>=8.3.4",

--- a/scdl/patches/mutagen_postprocessor.py
+++ b/scdl/patches/mutagen_postprocessor.py
@@ -94,7 +94,7 @@ class MutagenPP(PostProcessor):
     
     def _set_date(self, meta: dict, file):
         if not meta.get("date"):
-            return None, file
+            return file
               
         date = date_from_str(meta["date"])
         file = self._get_date_for_filetype(file, date)

--- a/scdl/patches/mutagen_postprocessor.py
+++ b/scdl/patches/mutagen_postprocessor.py
@@ -94,6 +94,9 @@ class MutagenPP(PostProcessor):
         return bool(tag in bypassed_list)
     
     def _set_date(self, meta: dict, file):
+        if not meta.get("date"):
+            return None, file
+              
         date = date_from_str(meta["date"])
         file = self._get_date_for_filetype(file, date)
         return date, file
@@ -105,7 +108,6 @@ class MutagenPP(PostProcessor):
             case "FLAC":
                 file["date"] = date.strftime(date_string)
             case "WAV" | "MP3" | "AIFF" | "DSDIFF" | "DSF" | "TrueAudio":
-                self.to_screen("im in the mp3 hahaaha")
                 file["TDRC"] = id3.TDRC(encoding=id3.Encoding.UTF8, text=date.strftime(date_string))
             case "OggOpus" | "OggSpeex" | "OggTheora" | "OggVorbis":
                 file["date"] = date.strftime(date_string)

--- a/scdl/patches/mutagen_postprocessor.py
+++ b/scdl/patches/mutagen_postprocessor.py
@@ -5,7 +5,7 @@ import contextlib
 import functools
 import os
 import re
-from typing import ClassVar
+from typing import ClassVar, Optional, List
 
 import mutagen
 from mutagen import (
@@ -73,9 +73,10 @@ class MutagenPP(PostProcessor):
         "tven": "episode_sort",
     }
 
-    def __init__(self, post_overwrites: bool, downloader=None):
+    def __init__(self, post_overwrites: bool, bypassed_list: Optional[List]=None, downloader=None, ):
         super().__init__(downloader)
         self._post_overwrites = post_overwrites
+        self.bypassed_list = bypassed_list or []
 
     def _get_flac_pic(self, thumbnail: dict) -> flac.Picture:
         pic = flac.Picture()
@@ -83,6 +84,34 @@ class MutagenPP(PostProcessor):
         pic.mime = f"image/{thumbnail['type']}"
         pic.type = id3.PictureType.COVER_FRONT
         return pic
+    
+    def _get_bypassed_list(self):
+        return self.bypassed_list
+    
+    def _check_tag_bypassed(self, tag: str):
+        """returns true if user wants tag to be bypassed"""
+        bypassed_list = self._get_bypassed_list() or []
+        return bool(tag in bypassed_list)
+    
+    def _set_date(self, meta: dict, file):
+        date = date_from_str(meta["date"])
+        file = self._get_date_for_filetype(file, date)
+        return date, file
+    
+    def _get_date_for_filetype(self, file, date,):
+        date_bypassed = self._check_tag_bypassed("date")
+        date_string = "%Y" if date_bypassed else "%Y-%m-%d"
+        match type(file).__name__:
+            case "FLAC":
+                file["date"] = date.strftime(date_string)
+            case "WAV" | "MP3" | "AIFF" | "DSDIFF" | "DSF" | "TrueAudio":
+                self.to_screen("im in the mp3 hahaaha")
+                file["TDRC"] = id3.TDRC(encoding=id3.Encoding.UTF8, text=date.strftime(date_string))
+            case "OggOpus" | "OggSpeex" | "OggTheora" | "OggVorbis":
+                file["date"] = date.strftime(date_string)
+            case "MP4":
+                file["\251day"] = date.strftime(date_string)
+        return file
 
     def _get_metadata_dict(self, info):
         meta_prefix = "meta"
@@ -143,11 +172,7 @@ class MutagenPP(PostProcessor):
             if meta.get(meta_key):
                 file[file_key] = meta[meta_key]
 
-        if meta.get("date"):
-            # Vorbis uses ISO 8601 format YYYY-MM-DD
-            date = date_from_str(meta["date"])
-            file["date"] = date.strftime("%Y-%m-%d")
-
+        date, file = self._set_date(meta, file)
         if meta.get("thumbnail"):
             pic = self._get_flac_pic(meta["thumbnail"])
             file.add_picture(pic)
@@ -161,10 +186,7 @@ class MutagenPP(PostProcessor):
             if meta.get(meta_key):
                 file[file_key] = meta[meta_key]
 
-        if meta.get("date"):
-            # Vorbis uses ISO 8601 format YYYY-MM-DD
-            date = date_from_str(meta["date"])
-            file["date"] = date.strftime("%Y-%m-%d")
+        date, file = self._set_date(meta, file)
 
         if meta.get("thumbnail"):
             pic = self._get_flac_pic(meta["thumbnail"])
@@ -185,10 +207,7 @@ class MutagenPP(PostProcessor):
                 else:
                     file[file_key] = id3_class(encoding=id3.Encoding.UTF8, text=meta[meta_key])
 
-        if meta.get("date"):
-            # ID3 uses ISO 8601 format YYYY-MM-DD
-            date = date_from_str(meta["date"])
-            file["TDRC"] = id3.TDRC(encoding=id3.Encoding.UTF8, text=date.strftime("%Y-%m-%d"))
+        date, file = self._set_date(meta, file)
 
         if meta.get("thumbnail"):
             file["APIC"] = id3.APIC(
@@ -204,11 +223,8 @@ class MutagenPP(PostProcessor):
         for file_key, meta_key in self._MP4_METADATA.items():
             if meta.get(meta_key):
                 file[file_key] = meta[meta_key]
-
-        if meta.get("date"):
-            # no standard but iTunes uses YYYY-MM-DD format
-            date = date_from_str(meta["date"])
-            file["\251day"] = date.strftime("%Y-%m-%d")
+                
+        date, file = self._set_date(meta, file)
 
         if meta.get("purl"):
             # https://getmusicbee.com/forum/index.php?topic=39759.0
@@ -280,6 +296,7 @@ class MutagenPP(PostProcessor):
             self._assemble_metadata(f, metadata)
             f.save()
         except Exception as err:
+            self.to_screen(err)
             raise MutagenPostProcessorError("Unable to embed metadata") from err
 
         return [], info

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -484,16 +484,15 @@ def _build_ytdl_params(url: str, scdl_args: SCDLArgs) -> tuple[str, dict, list]:
     if scdl_args.get("original_metadata"):
         params["--embed-metadata"] = False
         params["--embed-thumbnail"] = False
-    elif not scdl_args.get("original_metadata") and not scdl_args.get("only_year"):
-        postprocessors.append((MutagenPP(scdl_args["force_metadata"]), "post_process"))
-    
-    if scdl_args.get("original_metadata") and scdl_args.get("only_year"):
-        logger.error("[scdl] Invalid combination of arguments, cannot use --original-metadata and --only-year together")
-        sys.exit(1)
-        
-    if scdl_args.get("only_year"):
+        if scdl_args.get("only_year"):
+            logger.error("[scdl] Invalid combination of arguments, cannot use --original-metadata and --only-year together")
+            sys.exit(1)
+    elif scdl_args.get("only_year"):
         postprocessors.append((MutagenPP(scdl_args["force_metadata"], bypassed_list=["date"]), "post_process"))
-
+    else:
+        postprocessors.append((MutagenPP(scdl_args["force_metadata"]), "post_process"))
+        
+    
     if scdl_args.get("auth_token"):
         params["--username"] = "oauth"
         params["--password"] = scdl_args.get("auth_token")

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -70,7 +70,7 @@ Options:
     --add-description               Adds the description to a separate txt file
     --opus                          Prefer downloading opus streams over mp3 streams
     --impersonate [target]          Forward yt-dlp's --impersonate (requires curl_cffi)
-    --only-year                     Sets the year tag to be %yyyy% instead of %yyyy-%mm-%dd
+    --only-year                     Sets the year tag to be %yyyy instead of %yyyy-%mm-%dd
     --yt-dlp-args [argstring]       String with custom args to forward to yt-dlp
 """
 

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -9,7 +9,7 @@ Usage:
     [--original-name][--original-metadata][--no-original][--only-original]
     [--name-format <format>][--strict-playlist][--playlist-name-format <format>]
     [--client-id <id>][--auth-token <token>][--overwrite][--no-playlist][--opus]
-    [--add-description][--impersonate <target>][--yt-dlp-args <argstring>]
+    [--add-description][--impersonate <target>][--only-year][--yt-dlp-args <argstring>]
 
     scdl -h | --help
     scdl --version
@@ -70,6 +70,7 @@ Options:
     --add-description               Adds the description to a separate txt file
     --opus                          Prefer downloading opus streams over mp3 streams
     --impersonate [target]          Forward yt-dlp's --impersonate (requires curl_cffi)
+    --only-year                     Sets the year tag to be %yyyy% instead of %yyyy-%mm-%dd
     --yt-dlp-args [argstring]       String with custom args to forward to yt-dlp
 """
 
@@ -158,6 +159,7 @@ class SCDLArgs(TypedDict):
     t: bool
     impersonate: str | None
     yt_dlp_args: str
+    only_year: bool
 
 
 __version__ = importlib.metadata.version("scdl")
@@ -482,8 +484,15 @@ def _build_ytdl_params(url: str, scdl_args: SCDLArgs) -> tuple[str, dict, list]:
     if scdl_args.get("original_metadata"):
         params["--embed-metadata"] = False
         params["--embed-thumbnail"] = False
-    else:
+    elif not scdl_args.get("original_metadata") and not scdl_args.get("only_year"):
         postprocessors.append((MutagenPP(scdl_args["force_metadata"]), "post_process"))
+    
+    if scdl_args.get("original_metadata") and scdl_args.get("only_year"):
+        logger.error("[scdl] Invalid combination of arguments, cannot use force_metadata and only-year together")
+        sys.exit(1)
+        
+    if scdl_args.get("only_year"):
+        postprocessors.append((MutagenPP(scdl_args["force_metadata"], bypassed_list=["date"]), "post_process"))
 
     if scdl_args.get("auth_token"):
         params["--username"] = "oauth"

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -488,7 +488,7 @@ def _build_ytdl_params(url: str, scdl_args: SCDLArgs) -> tuple[str, dict, list]:
         postprocessors.append((MutagenPP(scdl_args["force_metadata"]), "post_process"))
     
     if scdl_args.get("original_metadata") and scdl_args.get("only_year"):
-        logger.error("[scdl] Invalid combination of arguments, cannot use force_metadata and only-year together")
+        logger.error("[scdl] Invalid combination of arguments, cannot use --original-metadata and --only-year together")
         sys.exit(1)
         
     if scdl_args.get("only_year"):


### PR DESCRIPTION
adds `--only-year` flag, which formats year tag as %yyyy% 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --only-year flag to show only the year for track dates; post-processing now respects this display option.
  * Validation prevents using --only-year together with original-metadata.

* **Bug Fixes**
  * Improved error reporting: warnings are issued before failures when post-processing errors occur.

* **Documentation**
  * README updated with contributing/development commands for linting, type-checking, and running tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->